### PR TITLE
Glue fixes

### DIFF
--- a/src/main/java/de/melanx/utilitix/content/slime/SlimeRender.java
+++ b/src/main/java/de/melanx/utilitix/content/slime/SlimeRender.java
@@ -5,6 +5,7 @@ import de.melanx.utilitix.Textures;
 import io.github.noeppi_noeppi.libx.render.RenderHelperBlock;
 import io.github.noeppi_noeppi.libx.render.RenderHelperLevel;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.culling.Frustum;
@@ -13,6 +14,7 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.phys.AABB;
@@ -22,30 +24,28 @@ import net.minecraftforge.client.event.RenderLevelLastEvent;
 public class SlimeRender {
 
     public static void renderWorld(RenderLevelLastEvent event) {
-        if (Minecraft.getInstance().level != null) {
+        ClientLevel level = Minecraft.getInstance().level;
+        if (level != null) {
             Minecraft.getInstance().getProfiler().push("utilitix_glue");
             Minecraft.getInstance().getTextureManager().getTexture(InventoryMenu.BLOCK_ATLAS);
             TextureAtlasSprite slime = Minecraft.getInstance().getTextureAtlas(InventoryMenu.BLOCK_ATLAS).apply(Textures.GLUE_OVERLAY_TEXTURE);
             if (slime != null) {
                 PoseStack poseStack = event.getPoseStack();
-                int size = Minecraft.getInstance().level.getChunkSource().storage.chunks.length();
+                int size = level.getChunkSource().storage.chunks.length();
                 Frustum clip = new Frustum(poseStack.last().pose(), event.getProjectionMatrix());
                 Vec3 projection = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
                 clip.prepare(projection.x, projection.y, projection.z);
                 Minecraft.getInstance().getProfiler().push("render_chunks");
                 for (int i = 0; i < size; i++) {
-                    LevelChunk chunk = Minecraft.getInstance().level.getChunkSource().storage.chunks.get(i);
+                    LevelChunk chunk = level.getChunkSource().storage.chunks.get(i);
                     if (chunk != null) {
                         ChunkPos pos = chunk.getPos();
-                        if (clip.isVisible(new AABB(pos.getMinBlockX(), 0, pos.getMinBlockZ(), pos.getMaxBlockX() + 1, 256, pos.getMaxBlockZ() + 1))) {
+                        if (clip.isVisible(new AABB(pos.getMinBlockX(), level.getMinBuildHeight(), pos.getMinBlockZ(), pos.getMaxBlockX() + 1, level.getMaxBuildHeight() + 1, pos.getMaxBlockZ() + 1))) {
                             //noinspection ConstantConditions
                             StickyChunk data = chunk.getCapability(SlimyCapability.STICKY_CHUNK).orElse(null);
                             //noinspection ConstantConditions
                             if (data != null) {
-                                poseStack.pushPose();
-                                RenderHelperLevel.loadProjection(poseStack, pos.getMinBlockX(), 0, pos.getMinBlockZ());
-                                renderChunk(poseStack, Minecraft.getInstance().renderBuffers().bufferSource(), pos, chunk, data, slime);
-                                poseStack.popPose();
+                                data.foreach(renderChunk(clip, poseStack, Minecraft.getInstance().renderBuffers().bufferSource(), pos, chunk, slime));
                             }
                         }
                     }
@@ -56,22 +56,47 @@ public class SlimeRender {
             Minecraft.getInstance().getProfiler().pop(); // utilitix_glue
         }
     }
+    
+    private static StickyChunk.ChunkAction renderChunk(Frustum clip, PoseStack poseStack, MultiBufferSource buffer, ChunkPos pos, LevelChunk chunk, TextureAtlasSprite slime) {
+        return (sectionId, sectionOffset) -> {
+            if (clip.isVisible(new AABB(pos.getMinBlockX(), sectionOffset, pos.getMinBlockZ(), pos.getMaxBlockX() + 1, sectionOffset + 16, pos.getMaxBlockZ() + 1))) {
+                return renderSection(poseStack, buffer, pos, sectionOffset, chunk, slime);
+            } else {
+                return null;
+            }
+        };
+    }
+    
+    private static StickyChunk.SectionAction renderSection(PoseStack poseStack, MultiBufferSource buffer, ChunkPos pos, int sectionOffset, LevelChunk chunk, TextureAtlasSprite slime) {
+        return new StickyChunk.SectionAction() {
+            
+            @Override
+            public void start() {
+                poseStack.pushPose();
+                RenderHelperLevel.loadProjection(poseStack, pos.getMinBlockX(), sectionOffset, pos.getMinBlockZ());
+                Minecraft.getInstance().getProfiler().push("render_chunk_glue");
+            }
 
-    private static void renderChunk(PoseStack poseStack, MultiBufferSource buffer, ChunkPos pos, LevelChunk chunk, StickyChunk data, TextureAtlasSprite slime) {
-        Minecraft.getInstance().getProfiler().push("render_chunk_glue");
-        data.foreach((x, y, z, flags) -> {
-            Minecraft.getInstance().getProfiler().push("do_render");
-            BlockPos block = new BlockPos(pos.getMinBlockX() + x, y, pos.getMinBlockZ() + z);
-            BlockState state = chunk.getBlockState(block);
-            int lightValue = state.getLightBlock(chunk, block);
-            int light = LightTexture.pack(lightValue, lightValue);
-            poseStack.pushPose();
-            poseStack.translate(x, y, z);
-            RenderHelperBlock.renderBlockOverlaySprite(state, poseStack, buffer, light, OverlayTexture.NO_OVERLAY, slime, state.getSeed(block), dir -> (flags & (1 << dir.ordinal())) != 0);
-            Minecraft.getInstance().renderBuffers().crumblingBufferSource().endBatch();
-            poseStack.popPose();
-            Minecraft.getInstance().getProfiler().pop(); // do_render
-        });
-        Minecraft.getInstance().getProfiler().pop(); // render_chunk_glue
+            @Override
+            public void accept(int x, int y, int z, byte data) {
+                Minecraft.getInstance().getProfiler().push("do_render");
+                BlockPos block = new BlockPos(pos.getMinBlockX() + x, sectionOffset + y, pos.getMinBlockZ() + z);
+                BlockState state = chunk.getBlockState(block);
+                int lightValue = state.getLightBlock(chunk, block);
+                int light = LightTexture.pack(lightValue, lightValue);
+                poseStack.pushPose();
+                poseStack.translate(x, y, z);
+                RenderHelperBlock.renderBlockOverlaySprite(state, poseStack, buffer, light, OverlayTexture.NO_OVERLAY, slime, state.getSeed(block), dir -> (data & (1 << dir.ordinal())) != 0);
+                Minecraft.getInstance().renderBuffers().crumblingBufferSource().endBatch();
+                poseStack.popPose();
+                Minecraft.getInstance().getProfiler().pop(); // do_render
+            }
+
+            @Override
+            public void stop() {
+                Minecraft.getInstance().getProfiler().pop(); // render_chunk_glue
+                poseStack.popPose();
+            }
+        };
     }
 }

--- a/src/main/java/de/melanx/utilitix/content/slime/StickySection.java
+++ b/src/main/java/de/melanx/utilitix/content/slime/StickySection.java
@@ -1,0 +1,119 @@
+package de.melanx.utilitix.content.slime;
+
+import de.melanx.utilitix.UtilitiX;
+import net.minecraft.core.Direction;
+import net.minecraft.network.FriendlyByteBuf;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class StickySection {
+    
+    private byte[] stickies;
+    // For performance
+    private Set<Integer> indicesWithGlue = null;
+    private final StickyChunk chunk;
+
+    public StickySection(StickyChunk chunk) {
+        this.chunk = chunk;
+        this.stickies = new byte[4096];
+    }
+
+    public boolean get(int x, int y, int z, Direction dir) {
+        int idx = ((y & 0xF) << 8) | ((z & 0xF) << 4) | (x & 0xF);
+        byte data = this.stickies[idx];
+        return (data & (1 << dir.ordinal())) != 0;
+    }
+
+    public void set(int x, int y, int z, Direction dir, boolean sticky) {
+        int idx = ((y & 0xF) << 8) | ((z & 0xF) << 4) | (x & 0xF);
+        if (sticky) {
+            this.stickies[idx] = (byte) (this.stickies[idx] | ((byte) (1 << dir.ordinal())));
+        } else {
+            this.stickies[idx] = (byte) (this.stickies[idx] & ~((byte) (1 << dir.ordinal())));
+        }
+        this.indicesWithGlue = null;
+        this.chunk.sync();
+    }
+
+    public byte getData(int x, int y, int z) {
+        int idx = ((y & 0xF) << 8) | ((z & 0xF) << 4) | (x & 0xF);
+        return this.stickies[idx];
+    }
+
+    public void setData(int x, int y, int z, byte data) {
+        int idx = ((y & 0xF) << 8) | ((z & 0xF) << 4) | (x & 0xF);
+        this.stickies[idx] = data;
+        this.indicesWithGlue = null;
+        this.chunk.sync();
+    }
+
+    public void clearData(int x, int y, int z) {
+        int idx = ((y & 0xF) << 8) | ((z & 0xF) << 4) | (x & 0xF);
+        this.stickies[idx] = 0;
+        this.indicesWithGlue = null;
+        this.chunk.sync();
+    }
+
+    public boolean canBeDiscarded() {
+        this.calculateIndicesWithGlueIfNeeded();
+        return this.indicesWithGlue.isEmpty();
+    }
+    
+    public void foreach(StickyChunk.SectionAction action) {
+        this.calculateIndicesWithGlueIfNeeded();
+        action.start();
+        try {
+            for (int idx : this.indicesWithGlue) {
+                byte data = this.stickies[idx];
+                if (data != 0) {
+                    int y = (idx >>> 8) & 0xF;
+                    int z = (idx >>> 4) & 0xF;
+                    int x = idx & 0xF;
+                    action.accept(x, y, z, data);
+                }
+            }
+        } finally {
+            action.stop();
+        }
+    }
+
+    private void calculateIndicesWithGlueIfNeeded() {
+        if (this.indicesWithGlue == null) {
+            this.indicesWithGlue = new HashSet<>();
+            for (int idx = 0; idx < this.stickies.length; idx++) {
+                byte data = this.stickies[idx];
+                if (data != 0) {
+                    this.indicesWithGlue.add(idx);
+                }
+            }
+        }
+    }
+    
+    public byte[] getStickies() {
+        byte[] copy = new byte[4096];
+        System.arraycopy(this.stickies, 0, copy, 0, 4096);
+        return copy;
+    }
+
+    public void setStickies(byte[] data) {
+        if (data.length != 4096) {
+            UtilitiX.getInstance().logger.error("Invalid size of sticky data for chunk section: " + data.length);
+            this.stickies = new byte[4096];
+            System.arraycopy(data, 0, this.stickies, 0, 4096);
+        } else {
+            this.stickies = data;
+            this.indicesWithGlue = null;
+        }
+    }
+    
+    public void writeRawDataToBuffer(FriendlyByteBuf buffer) {
+        buffer.writeBytes(this.stickies);
+    }
+    
+    public void readRawDataFromBuffer(FriendlyByteBuf buffer) {
+        this.stickies = new byte[4096];
+        buffer.readBytes(this.stickies);
+        this.indicesWithGlue = null;
+    }
+}

--- a/src/main/java/de/melanx/utilitix/content/wireless/WorldAndPos.java
+++ b/src/main/java/de/melanx/utilitix/content/wireless/WorldAndPos.java
@@ -1,5 +1,6 @@
 package de.melanx.utilitix.content.wireless;
 
+import io.github.noeppi_noeppi.libx.annotation.meta.RemoveIn;
 import io.github.noeppi_noeppi.libx.util.NBTX;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
@@ -11,6 +12,9 @@ import net.minecraft.world.level.Level;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
+// Use net.minecraft.core.GlobalPos
+@Deprecated(forRemoval = true)
+@RemoveIn(minecraft = "1.19")
 public class WorldAndPos {
 
     public final ResourceKey<Level> dimension;

--- a/src/main/java/de/melanx/utilitix/network/StickyChunkUpdateHandler.java
+++ b/src/main/java/de/melanx/utilitix/network/StickyChunkUpdateHandler.java
@@ -26,7 +26,7 @@ public class StickyChunkUpdateHandler {
                         StickyChunk glue = loaded.getCapability(SlimyCapability.STICKY_CHUNK).orElse(null);
                         //noinspection ConstantConditions
                         if (glue != null) {
-                            glue.setStickies(msg.data().getStickies());
+                            glue.loadFrom(msg.data());
                             return;
                         }
                     }

--- a/src/main/java/de/melanx/utilitix/network/StickyChunkUpdateSerializer.java
+++ b/src/main/java/de/melanx/utilitix/network/StickyChunkUpdateSerializer.java
@@ -14,16 +14,16 @@ public class StickyChunkUpdateSerializer implements PacketSerializer<StickyChunk
 
     @Override
     public void encode(StickyChunkUpdateMessage msg, FriendlyByteBuf buffer) {
-        buffer.writeInt(msg.pos.x);
-        buffer.writeInt(msg.pos.z);
-        buffer.writeByteArray(msg.data.getStickies());
+        buffer.writeInt(msg.pos().x);
+        buffer.writeInt(msg.pos().z);
+        msg.data().write(buffer);
     }
 
     @Override
     public StickyChunkUpdateMessage decode(FriendlyByteBuf buffer) {
         ChunkPos pos = new ChunkPos(buffer.readInt(), buffer.readInt());
         StickyChunk chunk = new StickyChunk();
-        chunk.setStickies(buffer.readByteArray());
+        chunk.read(buffer);
         return new StickyChunkUpdateMessage(pos, chunk);
     }
 

--- a/src/main/java/de/melanx/utilitix/network/UtiliNetwork.java
+++ b/src/main/java/de/melanx/utilitix/network/UtiliNetwork.java
@@ -12,7 +12,7 @@ public class UtiliNetwork extends NetworkX {
 
     @Override
     protected Protocol getProtocol() {
-        return Protocol.of("5");
+        return Protocol.of("6");
     }
 
     @Override


### PR DESCRIPTION
Fixes #17

Each chunk section will now only be stored if it at least contains one glue. Chunks saved with the old data format will be converted. This should reduce the amount of memory required and fix the bug that the world height was hardcoded to `256`. It should also increase the performance when rendering the glue as each chunk section is now clipped indenpendtly of the others.

Also this marks `WorldAndPos` as deprecated and to be removed in `1.19` as it is now possible to use `GlobalPos`. However that change will probably need to wait until `1.19` as the NBT format used by `GlobalPos` differs from `WorldAndPos`.