### PR TITLE
Small fix: limit wireless redstone power to 15 to prevent crashes

### DIFF
--- a/src/main/java/de/melanx/utilitix/content/wireless/BlockLinkedRepeater.java
+++ b/src/main/java/de/melanx/utilitix/content/wireless/BlockLinkedRepeater.java
@@ -223,7 +223,7 @@ public class BlockLinkedRepeater extends BlockBE<TileLinkedRepeater> {
         BlockPos targetPos = pos.relative(face);
         int i = level.getSignal(targetPos, face);
         if (i >= 15) {
-            return i;
+            return 15;
         } else {
             BlockState targetState = level.getBlockState(targetPos);
             return Math.max(i, targetState.is(Blocks.REDSTONE_WIRE) ? targetState.getValue(BlockStateProperties.POWER) : 0);


### PR DESCRIPTION
Some mods produce redstone level of more than 15. Setting the linked repeater's block state to such value will cause a crash.
```
java.lang.IllegalArgumentException: Cannot set property IntegerProperty{name=power, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]} to 16 on Block{utilitix:linked_repeater}, it is not an allowed value
        at net.minecraft.world.level.block.state.StateHolder.m_61124_(StateHolder.java:130) ~[server-1.20.1-20230612.114412-srg.jar%23931!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:ferritecore.fastmap.mixin.json:FastMapStateHolderMixin,pl:mixin:A}
        at de.melanx.utilitix.content.wireless.BlockLinkedRepeater.m_213897_(BlockLinkedRepeater.java:208) ~[UtilitiX-1.20.1-0.8.10.jar%23906!/:1.20.1-0.8.10] {re:classloading,pl:runtimedistcleaner:A}
```